### PR TITLE
fix version conflict on M4

### DIFF
--- a/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCC-4.7.2.eb
+++ b/easybuild/easyconfigs/l/libtool/libtool-2.4.6-GCC-4.7.2.eb
@@ -12,6 +12,6 @@ toolchain = {'name': 'GCC', 'version': '4.7.2'}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [GNU_SOURCE]
 
-dependencies = [('M4', '1.4.17')]
+dependencies = [('M4', '1.4.16')]
 
 moduleclass = 'lib'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/2096

Autoconf built with GCC 4.7.2 depends on M4 1.4.16, so libtool must do so too since they're used together in the Autotools bundle

@riccardomurri: please merge?
