### PR TITLE
don't hard overwrite $CPATH in prebuildopts in Mesa easyconfig files

### DIFF
--- a/easybuild/easyconfigs/m/Mesa/Mesa-10.4.5-intel-2015a-Python-2.7.9.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-10.4.5-intel-2015a-Python-2.7.9.eb
@@ -59,7 +59,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --disable-egl"
 # package-config files for os dependencies are in an os specific place
 #preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-10.5.5-intel-2015a-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-10.5.5-intel-2015a-Python-2.7.10.eb
@@ -57,7 +57,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='swrast' --disabl
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.0.2-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.0.2-intel-2015b-Python-2.7.10.eb
@@ -56,7 +56,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='swrast' --disabl
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.0.8-intel-2015b-Python-2.7.11.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.0.8-intel-2015b-Python-2.7.11.eb
@@ -56,7 +56,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='swrast' --disabl
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.so', 'lib/libOSMesa.so',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-gimkl-2.11.5.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-gimkl-2.11.5.eb
@@ -53,7 +53,7 @@ configopts += " --with-osmesa-bits=32 --enable-texture-float "
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT, 'lib/libGLESv1_CM.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-intel-2016a.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-11.1.2-intel-2016a.eb
@@ -53,7 +53,7 @@ configopts += " --with-osmesa-bits=32 --enable-texture-float "
 #preconfigopts = 'libtoolize && PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 preconfigopts = ' libtoolize &&  '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libOSMesa.%s' % SHLIB_EXT, 'lib/libGLESv1_CM.%s' % SHLIB_EXT,

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -44,7 +44,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goolf-1.4.10-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-goolf-1.4.10-Python-2.7.3.eb
@@ -43,7 +43,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.0.6-Python-2.7.3.eb
@@ -44,7 +44,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.1.13-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-4.1.13-Python-2.7.3.eb
@@ -44,7 +44,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.3.0-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.3.0-Python-2.7.3.eb
@@ -45,7 +45,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',

--- a/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.5.0-Python-2.7.6.eb
+++ b/easybuild/easyconfigs/m/Mesa/Mesa-7.11.2-ictce-5.5.0-Python-2.7.6.eb
@@ -45,7 +45,7 @@ configopts += " --disable-driglx-direct --with-gallium-drivers='' --without-demo
 # package-config files for os dependencies are in an os specific place
 preconfigopts = ' PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/lib64/pkgconfig/:/usr/share/pkgconfig" '
 
-prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm" '
+prebuildopts = 'env CPATH="$EBROOTLIBDRM/include/libdrm:$CPATH" '
 
 sanity_check_paths = {
     'files': ['lib/libGL.%s' % SHLIB_EXT, 'lib/libGLU.%s' % SHLIB_EXT, 'include/GL/glext.h', 'include/GL/gl_mangle.h',


### PR DESCRIPTION
I noticed this while reviewing https://github.com/hpcugent/easybuild-easyconfigs/pull/2811, hard redefining `$CPATH` without taking into account the current value is not a good idea...
